### PR TITLE
Fixed plugin double borrowing in vst3 parameter handler

### DIFF
--- a/plinth-plugin/src/formats/vst3/host.rs
+++ b/plinth-plugin/src/formats/vst3/host.rs
@@ -58,15 +58,19 @@ impl<P: Plugin> Host for Vst3Host<P> {
     }
 
     fn change_parameter_value(&self, id: ParameterId, normalized: ParameterValue) {
-        let plugin = self.plugin.borrow();
-        let Some(plugin) = plugin.as_ref() else {
-            return;
-        };
+        {
+            let plugin = self.plugin.borrow();
+            let Some(plugin) = plugin.as_ref() else {
+                return;
+            };
 
-        plugin.with_parameters(|parameters| {
-            let parameter = parameters.get(id).unwrap();
-            parameter.set_normalized_value(normalized).unwrap();
-        });
+            plugin.with_parameters(|parameters| {
+                let parameter = parameters.get(id).unwrap();
+                parameter.set_normalized_value(normalized).unwrap();
+            });
+            
+            // release plugin.borrow before calling performEdit
+        } 
 
         if let Some(handler) = self.component_handler.borrow_mut().as_mut() {
             unsafe { handler.performEdit(id, normalized) };


### PR DESCRIPTION
Firstly, thanks for the great library and massive effort! I've been looking for a way to use slint-ui in Rust plugins for a while before I found this.

Not sure what your contribution guidelines are - if you're interested in PRs at all. So, if not, simply close this one and I'll stop. Otherwise, I'd be happy to contribute a few other little things I've stumbled upon while testing/using it.

Back to topic:
- release plugin borrow in `change_parameter_value` before calling `performEdit`, which very likely will try to borrow the plugin instance again
- fixes a possible panic when changing a VST3 plugin parameter via its external editor