### PR TITLE
Fix custom Slint cursor display on Windows

### DIFF
--- a/plugin-canvas/src/platform/win32/window.rs
+++ b/plugin-canvas/src/platform/win32/window.rs
@@ -7,7 +7,7 @@ use keyboard_types::Code;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawWindowHandle, Win32WindowHandle};
 use uuid::Uuid;
 use windows::Win32::UI::Input::KeyboardAndMouse::SetFocus;
-use windows::Win32::UI::WindowsAndMessaging::{GetParent, WM_CANCELMODE, WM_SETFOCUS};
+use windows::Win32::UI::WindowsAndMessaging::{GetParent, WM_CANCELMODE, WM_SETFOCUS, WM_SETCURSOR};
 use windows::{core::PCWSTR, Win32::UI::Input::KeyboardAndMouse::{VK_LWIN, VK_RWIN}};
 use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, POINT, WPARAM};
 use windows::Win32::Graphics::{Dwm::{DwmFlush, DwmIsCompositionEnabled}, Dxgi::{CreateDXGIFactory, IDXGIFactory, IDXGIOutput}, Gdi::{ClientToScreen, MonitorFromWindow, ScreenToClient, HBRUSH, MONITOR_DEFAULTTOPRIMARY}};
@@ -471,6 +471,11 @@ unsafe extern "system" fn wnd_proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam:
 
                     DefWindowProcW(hwnd, msg, wparam, lparam)
                 }
+            }
+
+            WM_SETCURSOR => {
+                // Don't call DefWindowProcW to avoid that parent windows get a chance to revert or change ours (from `Self::set_cursor`)
+                LRESULT(1)
             }
 
             _ => unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) },


### PR DESCRIPTION
Need to handle WM_CURSOR in OsWindow to avoid that parent windows get a chance to restore the cursor to the default cursor after a custom cursor got set via `SetCursor`.

To replicate: open the gain plugin example (VST3 or standalone) before this change on Windows. The custom Resize cursor on the gain text will only briefly show (if at all) and then will revert to the default cursor again. After this fix it should stay a resize cursor as long as the gain text is hovered.